### PR TITLE
Bug fix pagebuilder settings

### DIFF
--- a/src/view/adminhtml/layout/emico_attributelanding_overviewpage_edit.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_overviewpage_edit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
-    <update handle="editor"/>
+	<update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_overviewpage_form"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_overviewpage_edit.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_overviewpage_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
+    <update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_overviewpage_form"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_overviewpage_index.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_overviewpage_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
-    <update handle="editor"/>
+	<update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_overviewpage_listing"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_overviewpage_index.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_overviewpage_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
+    <update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_overviewpage_listing"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_page_edit.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_page_edit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
-    <update handle="editor"/>
+	<update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_page_form"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_page_edit.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_page_edit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
+    <update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_page_form"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_page_index.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_page_index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
-    <update handle="editor"/>
+	<update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_page_listing"/>

--- a/src/view/adminhtml/layout/emico_attributelanding_page_index.xml
+++ b/src/view/adminhtml/layout/emico_attributelanding_page_index.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
 	<update handle="styles"/>
+    <update handle="editor"/>
 	<body>
 		<referenceContainer name="content">
 			<uiComponent name="emico_attributelanding_page_listing"/>


### PR DESCRIPTION
On the attribute landing pages/overview pages the pagebuilder configure options don't work in the admin. See screenshot

![de208603-a455-4451-9c56-e1f819d5b408](https://user-images.githubusercontent.com/103565001/169280368-4ef9a5c4-616a-4afe-aa9e-8c36e34f16bc.png)

