### PR TITLE
Fix empty content bug

### DIFF
--- a/src/Block/OverviewPage/View.php
+++ b/src/Block/OverviewPage/View.php
@@ -111,7 +111,7 @@ class View extends Template
      */
     public function getContentFirst(): string
     {
-        return $this->getFilteredContent($this->getOverviewPage()->getContentFirst());
+        return $this->getFilteredContent($this->getOverviewPage()->getContentFirst() ?? '');
     }
 
     /**
@@ -119,7 +119,7 @@ class View extends Template
      */
     public function getContentLast(): string
     {
-        return $this->getFilteredContent($this->getOverviewPage()->getContentLast());
+        return $this->getFilteredContent($this->getOverviewPage()->getContentLast() ?? '');
     }
 
     /**


### PR DESCRIPTION
Fixes bug in overview page
Emico\AttributeLanding\Block\OverviewPage\View::getFilteredContent() must be of the type string, null given

How to reproduce

- Make an overview page with an empty first en last content section.
- View the page on the frontend