### PR TITLE
Bug adobe commerce compatibiity

### DIFF
--- a/src/Setup/UpgradeSchema.php
+++ b/src/Setup/UpgradeSchema.php
@@ -37,8 +37,9 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 $columnName,
                 'CASCADE',
             );
+        }
 
-            if ($connection->tableColumnExists($tableName, 'entity_id')) {
+        if ($connection->tableColumnExists($tableName, 'entity_id')) {
             //open source version
             $connection->addForeignKey(
                 'EMICO_ATTRLANDING_PAGE_CTGR_ID_CAT_CTGR_ENTT_ENTT_ID',

--- a/src/Setup/UpgradeSchema.php
+++ b/src/Setup/UpgradeSchema.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Emico\AttributeLanding\Setup;
+
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * Upgrades DB schema for a module
+     *
+     * @param SchemaSetupInterface $setup
+     * @param ModuleContextInterface $context
+     * @return void
+     * @throws \Zend_Db_Exception
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $installer = $setup;
+        $installer->startSetup();
+        $connection = $installer->getConnection();
+
+
+        $tableName = 'catalog_category_entity';
+        $columnName = 'row_id';
+        if ($connection->tableColumnExists($tableName, $columnName)) {
+            //adobe commerce version
+            $connection->addForeignKey(
+                'EMICO_ATTRLANDING_PAGE_CTGR_ID_CAT_CTGR_ENTT_ENTT_ID',
+                'emico_attributelanding_page',
+                'category_id',
+                $tableName,
+                $columnName,
+                'CASCADE',
+            );
+
+            if ($connection->tableColumnExists($tableName, 'entity_id')) {
+            //open source version
+            $connection->addForeignKey(
+                'EMICO_ATTRLANDING_PAGE_CTGR_ID_CAT_CTGR_ENTT_ENTT_ID',
+                'emico_attributelanding_page',
+                'category_id',
+                $tableName,
+                'entity_id',
+                'CASCADE',
+            );
+        }
+
+        $installer->endSetup();
+    }
+}
+

--- a/src/etc/db_schema.xml
+++ b/src/etc/db_schema.xml
@@ -26,9 +26,6 @@
         <column xsi:type="int" name="tweakwise_sort_template" nullable="true" comment="Tweakwise sort template"/>
         <constraint xsi:type="primary" referenceId="PRIMARY"><column name="page_id"/></constraint>
         <index referenceId="EMICO_ATTRIBUTELANDING_PAGE_URL_PATH" indexType="btree"><column name="url_path"/></index>
-        <constraint xsi:type="foreign" referenceId="EMICO_ATTRLANDING_PAGE_CTGR_ID_CAT_CTGR_ENTT_ENTT_ID"
-                    table="emico_attributelanding_page" column="category_id"
-                    referenceTable="catalog_category_entity" referenceColumn="entity_id" onDelete="CASCADE"/>
         <constraint xsi:type="foreign" referenceId="EMICO_ATTRLANDING_PAGE_OVERVIEW_PAGE"
                     table="emico_attributelanding_page" column="overview_page_id"
                     referenceTable="emico_attributelanding_overviewpage" referenceColumn="page_id" onDelete="SET NULL"/>

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Emico_AttributeLanding" setup_version="1.0.1">
+    <module name="Emico_AttributeLanding" setup_version="1.0.2">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_LayeredNavigation"/>


### PR DESCRIPTION
When installing the module in the magegento adobe commerce version you get the following error

Column definition "category_id" and reference column definition "entity_id" are different in tables "emico_attributelanding_page" and "catalog_category_entity"

This is caused by a different table structure of the catalog_category_entity table. The following fix modifies the initial table setup and removes an foreign key.

The upgrade script then checks if the commerce column exists and adds an foreign key for both options.

This issue is tested on the opensource version, but not on the adobe commerce version because I do not have a test environment for the commerce version. **Before merging this should be tested on the commerce version to make sure that the foreign key is added correctly., and linking an attribute page to an category is working**