### PR TITLE
Move block remove directives inside body tag

### DIFF
--- a/src/view/frontend/layout/emico_attributelanding_landingpage_view.xml
+++ b/src/view/frontend/layout/emico_attributelanding_landingpage_view.xml
@@ -3,13 +3,13 @@
     <update handle="catalog_category_view"/>
     <update handle="catalog_category_view_type_layered"/>
     <body>
+        <!-- Remove original category blocks -->
+        <referenceBlock name="category.cms" remove="true"/>
+        <referenceBlock name="category.image" remove="true"/>
+        <referenceBlock name="category.description" remove="true"/>
         <referenceContainer name="content">
             <block class="Emico\AttributeLanding\Block\LandingPage\Content" name="attributelanding.content_top" template="Emico_AttributeLanding::landing-page/top-content.phtml" before="category.products" />
             <block class="Emico\AttributeLanding\Block\LandingPage\Content" name="attributelanding.content_bottom" template="Emico_AttributeLanding::landing-page/bottom-content.phtml" after="category.products" />
         </referenceContainer>
     </body>
-    <!-- Remove original category blocks -->
-    <referenceBlock name="category.cms" remove="true"/>
-    <referenceBlock name="category.image" remove="true"/>
-    <referenceBlock name="category.description" remove="true"/>
 </page>


### PR DESCRIPTION
The XML structure for emico_attributelanding_landingpage_view.xml is currently not correct:

Only `update`, `head`, `body` and `html` tags are allowed inside the `page` tag in XML layout files.
`referenceBlock` and `referenceContainer` are allowed inside the body tag.
See `magento/framework/View/Layout/etc/page_configuration.xsd`