### PR TITLE
Make matching landingpage to a filter less error prone

### DIFF
--- a/src/Model/UrlFinder.php
+++ b/src/Model/UrlFinder.php
@@ -95,7 +95,7 @@ class UrlFinder
             ['category|' . $categoryId],
             array_map(
                 function(FilterInterface $filter) {
-                    return $filter->getFacet() . '|' . $filter->getValue();
+                    return strtolower($filter->getFacet() . '|' . $filter->getValue());
                 },
                 $filters
             )


### PR DESCRIPTION
Always match everything lowercase