### PR TITLE
Don't make root category selectable

### DIFF
--- a/src/Ui/Component/Product/Form/Categories/Options.php
+++ b/src/Ui/Component/Product/Form/Categories/Options.php
@@ -1,0 +1,68 @@
+<?php
+namespace Emico\AttributeLanding\Ui\Component\Product\Form\Categories;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\Framework\App\RequestInterface;
+use Magento\Catalog\Model\Category as CategoryModel;
+
+/**
+ * Options tree for "Categories" field
+ */
+class Options extends \Magento\Catalog\Ui\Component\Product\Form\Categories\Options implements OptionSourceInterface
+{
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Category\CollectionFactory
+     */
+    protected $categoryCollectionFactory;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var array
+     */
+    protected $categoriesTree;
+
+    /**
+     * @param CategoryCollectionFactory $categoryCollectionFactory
+     * @param RequestInterface $request
+     */
+    public function __construct(
+        CategoryCollectionFactory $categoryCollectionFactory,
+        RequestInterface $request
+    ) {
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->request = $request;
+    }
+
+    /**
+     * Retrieve categories tree
+     *
+     * @return array
+     */
+    protected function getCategoriesTree()
+    {
+        if ($this->categoriesTree === null) {
+            $this->categoriesTree = parent::getCategoriesTree();
+
+            $categoriesWithoutRoot = [];
+
+            //remove root category and add root category label
+            foreach ($this->categoriesTree as $rootCategory) {
+                foreach($rootCategory['optgroup'] as &$subCategory) {
+                    $subCategory['label'] .= ' ('.$rootCategory['label'].')';
+                }
+                if (isset( $rootCategory['optgroup'])) {
+                    $categoriesWithoutRoot = array_merge($categoriesWithoutRoot, $rootCategory['optgroup']);
+                }
+            }
+
+            $this->categoriesTree = $categoriesWithoutRoot;
+        }
+
+        return $this->categoriesTree;
+    }
+}

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -101,6 +101,7 @@
 		</field>
 		<field formElement="select" name="category_id" sortOrder="30">
 			<argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">Emico\AttributeLanding\Ui\Component\Product\Form\Categories\Options</item>
 				<item name="config" xsi:type="array">
 					<item name="componentType" xsi:type="string">field</item>
 					<item name="component" xsi:type="string">Magento_Catalog/js/components/new-category</item>


### PR DESCRIPTION
Fixes #31 

Selecting the root category in an attribute landingspage results in the wrong url's when unselecting/clearing filters. This is caused because the root category isn't available from an url/menu in magento. And the system can't resolve an url for it.

Since this root category isn't available by url by magento by design i've made a fix that removes the root category from the select so you can't select the root category in an attribute landingpage.
