### PR TITLE
Fix Landing page url

### DIFF
--- a/src/Block/Catalog/Breadcrumbs.php
+++ b/src/Block/Catalog/Breadcrumbs.php
@@ -32,6 +32,11 @@ class Breadcrumbs extends CatalogBreadcrumbs
     private $overviewPageRepository;
 
     /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    private \Magento\Framework\UrlInterface $urlInterface;
+
+    /**
      * @param Context $context
      * @param Data $catalogData
      * @param LandingPageContext $landingPageContext
@@ -43,11 +48,13 @@ class Breadcrumbs extends CatalogBreadcrumbs
         Data $catalogData,
         LandingPageContext $landingPageContext,
         OverviewPageRepositoryInterface $overviewPageRepository,
+        \Magento\Framework\UrlInterface $urlInterface,
         array $data = []
     ) {
         parent::__construct($context, $catalogData, $data);
         $this->landingPageContext = $landingPageContext;
         $this->overviewPageRepository = $overviewPageRepository;
+        $this->urlInterface = $urlInterface;
     }
 
     /**
@@ -96,7 +103,7 @@ class Breadcrumbs extends CatalogBreadcrumbs
                 [
                     'label' => __($overviewPage->getName()),
                     'title' => __($overviewPage->getName()),
-                    'link' => $overviewPage->getUrlPath()
+                    'link' => $this->urlInterface->getUrl( $overviewPage->getUrlPath() )
                 ]
             );
         }


### PR DESCRIPTION
The landing page url was missing the slash at the start making relative urls.
This will let magento make full urls fixing the breadcrumbs.