### PR TITLE
Fix syntax error

### DIFF
--- a/src/Console/Command/RegenerateUrlRewrites.php
+++ b/src/Console/Command/RegenerateUrlRewrites.php
@@ -30,7 +30,7 @@ class RegenerateUrlRewrites extends Command
         LandingPageRepositoryInterface $landingPageRepository,
         OverviewPageRepositoryInterface $overviewPageRepository,
         SearchCriteriaBuilder $searchCriteriaBuilder,
-        UrlRewriteService $urlRewriteService,
+        UrlRewriteService $urlRewriteService
     ) {
         parent::__construct();
         $this->landingPageRepository = $landingPageRepository;


### PR DESCRIPTION
Since #52 the setup:upgrade command is broken (on php 7.4) because of an syntax error in the constructor. You can't add an , at the end of arguments in the constructor.