### PR TITLE
Update emico_attributelanding_page_form.xml

### DIFF
--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -242,7 +242,7 @@
 			<formElements>
 				<select>
 					<settings>
-						<options class="Emico\Tweakwise\Model\Config\Source\FilterTemplate" />
+						<options class="Tweakwise\Magento2Tweakwise\Model\Config\Source\FilterTemplate" />
 					</settings>
 				</select>
 			</formElements>
@@ -266,7 +266,7 @@
 			<formElements>
 				<select>
 					<settings>
-						<options class="Emico\Tweakwise\Model\Config\Source\SortTemplate" />
+						<options class="Tweakwise\Magento2Tweakwise\Model\Config\Source\SortTemplate" />
 					</settings>
 				</select>
 			</formElements>


### PR DESCRIPTION
The attribute landing page doesn't work properly anymore with tweakwise/magento2tweakwise installed. This pull requests fixes this.

@bramstroker Should this be a major version change, since you need to use the tweakwise/magento2tweakwise package instead of emico/tweakwise?
And should the dependency on tweakwise be added in the composer.json?