### PR TITLE
Make root category selectable

### DIFF
--- a/src/Model/LandingPageRepository.php
+++ b/src/Model/LandingPageRepository.php
@@ -9,6 +9,8 @@ namespace Emico\AttributeLanding\Model;
 use Emico\AttributeLanding\Api\Data\OverviewPageInterface;
 use Emico\AttributeLanding\Api\Data\LandingPageInterface;
 use Emico\AttributeLanding\Api\LandingPageRepositoryInterface;
+use Emico\AttributeLanding\Ui\Component\Product\Form\Categories\Options;
+use Magento\Catalog\Model\CategoryManagement;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Emico\AttributeLanding\Api\Data\PageSearchResultsInterfaceFactory;
@@ -78,7 +80,8 @@ class LandingPageRepository implements LandingPageRepositoryInterface
         CollectionProcessorInterface $collectionProcessor,
         JoinProcessorInterface $extensionAttributesJoinProcessor,
         SearchCriteriaBuilder $searchCriteriaBuilder,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        Options $options
     ) {
         $this->resource = $resource;
         $this->pageCollectionFactory = $pageCollectionFactory;
@@ -88,6 +91,7 @@ class LandingPageRepository implements LandingPageRepositoryInterface
         $this->extensionAttributesJoinProcessor = $extensionAttributesJoinProcessor;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->storeManager = $storeManager;
+        $this->options = $options;
     }
 
     /**
@@ -96,6 +100,20 @@ class LandingPageRepository implements LandingPageRepositoryInterface
     public function save(LandingPageInterface $page): LandingPageInterface
     {
         try {
+            $tree = $this->options->getCategoriesTree();
+            $rootCategories = [];
+
+            //set hide filters for root categories
+            if (!empty($tree)) {
+                foreach ($tree as $rootCategory) {
+                    $rootCategories[] = $rootCategory['value'];
+                }
+            }
+
+            if (in_array($page->getData('category_id'), $rootCategories)) {
+                $page->setData('hide_selected_filters', "1");
+            }
+
             /** @var LandingPage $page */
             $this->resource->save($page);
         } catch (\Exception $exception) {

--- a/src/Ui/Component/Product/Form/Categories/Options.php
+++ b/src/Ui/Component/Product/Form/Categories/Options.php
@@ -43,24 +43,10 @@ class Options extends \Magento\Catalog\Ui\Component\Product\Form\Categories\Opti
      *
      * @return array
      */
-    protected function getCategoriesTree()
+    public function getCategoriesTree()
     {
         if ($this->categoriesTree === null) {
             $this->categoriesTree = parent::getCategoriesTree();
-
-            $categoriesWithoutRoot = [];
-
-            //remove root category and add root category label
-            foreach ($this->categoriesTree as $rootCategory) {
-                if (isset($rootCategory['optgroup'])) {
-                    foreach ($rootCategory['optgroup'] as &$subCategory) {
-                        $subCategory['label'] .= ' (' . $rootCategory['label'] . ')';
-                    }
-                    $categoriesWithoutRoot = array_merge($categoriesWithoutRoot, $rootCategory['optgroup']);
-                }
-            }
-
-            $this->categoriesTree = $categoriesWithoutRoot;
         }
 
         return $this->categoriesTree;

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -206,6 +206,7 @@
 			<settings>
 				<dataType>text</dataType>
 				<label translate="true">Hide selected filters</label>
+                <notice>Always yes for root categories</notice>
 				<dataScope>hide_selected_filters</dataScope>
 				<validation>
 					<rule name="required-entry" xsi:type="boolean">false</rule>


### PR DESCRIPTION
Makes the root category selectable again. Because the root category has problems with clearing the filters if hide selected filters is not set to yes, hide selected filters is set to yes.

So if you select an root category, hide selected filters is automatically (on save) set to yes.