### PR TITLE
Removed store id filter

### DIFF
--- a/src/Model/LandingPageRepository.php
+++ b/src/Model/LandingPageRepository.php
@@ -203,11 +203,8 @@ class LandingPageRepository implements LandingPageRepositoryInterface
      */
     public function findAllActive(): array
     {
-        $storeId = $this->storeManager->getStore()->getId();
-
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilter(LandingPageInterface::ACTIVE, 1)
-            ->addFilter(LandingPageInterface::STORE_IDS, [$storeId, 0], 'in')
             ->create();
 
         $result = $this->getList($searchCriteria);


### PR DESCRIPTION
# Problem
The store ids filter does not work when multiple stores are selected. Once multiple stores are selected the value in the database is e.g. '1,2,3' translating to store_id = 1, 2 & 3.

The filter being used translates to `'store_ids', ['1,2,3', 0], 'in'` for value `1,2,3`. It wil only work once the DB value is a single store which translates to `'store_ids', ['1,2,3', 0], 'in'` for value `1`.

The 'in' filter uses an array of values to search for a specific value. It does not work when searching in an array of values.

# Suggestion
My suggestion would be to handle the store specific logic when saving an ALP. Not when retrieving one.