### PR TITLE
Change type category id to always be int

### DIFF
--- a/src/Api/Data/LandingPageInterface.php
+++ b/src/Api/Data/LandingPageInterface.php
@@ -218,10 +218,10 @@ interface LandingPageInterface extends ExtensibleDataInterface
     public function setName(?string $name): LandingPageInterface;
 
     /**
-     * @param string|null $categoryId
+     * @param int|null $categoryId
      * @return LandingPageInterface
      */
-    public function setCategoryId( ?string $categoryId): LandingPageInterface;
+    public function setCategoryId( ?int $categoryId): LandingPageInterface;
 
     /**
      * @param string|null $heading

--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -167,7 +167,7 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
 
     /**
      * Get category_id
-     * @return string|null
+     * @return int|null
      */
     public function getCategoryId()
     {
@@ -176,10 +176,10 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
 
     /**
      * Set category_id
-     * @param string $categoryId
+     * @param int $categoryId
      * @return \Emico\AttributeLanding\Api\Data\LandingPageInterface
      */
-    public function setCategoryId( ?string $categoryId): LandingPageInterface
+    public function setCategoryId( ?int $categoryId): LandingPageInterface
     {
         return $this->setData(self::CATEGORY_ID, $categoryId);
     }


### PR DESCRIPTION
The category ID is expected to be an integer, but in some instances, a string was being used. This pull request addresses and resolves this inconsistency.