### PR TITLE
fix: show 404 when page is not active for store

### DIFF
--- a/src/Controller/LandingPage/View.php
+++ b/src/Controller/LandingPage/View.php
@@ -18,6 +18,7 @@ use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 class View extends Action
 {
@@ -52,6 +53,11 @@ class View extends Action
     private $landingPageContext;
 
     /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
      * Constructor
      *
      * @param Context $context
@@ -69,13 +75,15 @@ class View extends Action
         Registry $registry,
         LandingPageRepositoryInterface $landingPageRepository,
         CategoryRepositoryInterface $categoryRepository,
-        FilterApplierInterface $filterApplier
+        FilterApplierInterface $filterApplier,
+        StoreManagerInterface $storeManager
     ) {
         $this->resultPageFactory = $resultPageFactory;
         $this->coreRegistry = $registry;
         $this->landingPageRepository = $landingPageRepository;
         $this->categoryRepository = $categoryRepository;
         $this->filterApplier = $filterApplier;
+        $this->storeManager = $storeManager;
         parent::__construct($context);
         $this->landingPageContext = $landingPageContext;
     }
@@ -95,6 +103,13 @@ class View extends Action
 
         if (!$landingPage->isActive()) {
             throw new NotFoundException(__('Page not active'));
+        }
+
+        $storeId = $this->storeManager->getStore()->getId();
+        $landingPageStoreIds = $landingPage->getStoreIds();
+
+        if ((!in_array($storeId, $landingPage->getStoreIds())) && (!in_array(0, $landingPage->getStoreIds()))) {
+            throw new NotFoundException(__('Page not active for this store'));
         }
 
         $this->landingPageContext->setLandingPage($landingPage);


### PR DESCRIPTION
When an page is not active for an certain store. You can still visit the page via the url with emico_attributelanding/landingPage/view/id/2 as url. 

This pull request checks if that page is active for the current store. If not show an 404.