### PR TITLE
Fix: bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "emico/m2-attributelanding",
     "description": "Attribute landing pages for Magento 2",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "magento/module-sitemap": "^100.2||^100.4",
         "magento/module-catalog": "^102.0||^103.0||^104.0"
     },


### PR DESCRIPTION
Bump minimum php version to 8.1. Php 8.1 is needed since the recommendation changes, but it wasn't updated in the composer.json.