### PR TITLE
fix: ALP url with trailing slash

### DIFF
--- a/src/Model/UrlRewriteService.php
+++ b/src/Model/UrlRewriteService.php
@@ -132,6 +132,8 @@ class UrlRewriteService
                 ? $page->getUrlRewriteRequestPath()
                 : $page->getUrlPath() . $suffix;
 
+            $requestPath = trim($requestPath, '/');
+
             $urlRewrite->setRequestPath($requestPath);
             $urlRewritesToPersist[] = $urlRewrite;
         }


### PR DESCRIPTION
When an ALP has an url ending in an trailing slash (url/) than the filters don't work if you use the url path slug strategy.

This pull request removes the trailing (and starting) slash to prevent this issue. The starting and trailing slash should always be removed.