### PR TITLE
Fix: facet link

### DIFF
--- a/src/Model/LandingPageRepository.php
+++ b/src/Model/LandingPageRepository.php
@@ -268,8 +268,8 @@ class LandingPageRepository implements LandingPageRepositoryInterface
         $storeId = $this->storeManager->getStore()->getId();
 
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter(LandingPageInterface::ACTIVE, 1)
-            ->addFilter(LandingPageInterface::STORE_ID, [$storeId, 0], 'in')
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::ACTIVE, 1)
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::STORE_ID, [$storeId, 0], 'in')
             ->create();
 
         $result = $this->getList($searchCriteria);
@@ -285,7 +285,7 @@ class LandingPageRepository implements LandingPageRepositoryInterface
     {
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilter(LandingPageInterface::OVERVIEW_PAGE_ID, $overviewPage->getPageId())
-            ->addFilter(LandingPageInterface::ACTIVE, 1)
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::ACTIVE, 1)
             ->create();
 
         $result = $this->getList($searchCriteria);

--- a/src/Model/ResourceModel/Page.php
+++ b/src/Model/ResourceModel/Page.php
@@ -34,7 +34,7 @@ class Page extends AbstractDb
      */
     protected function _construct(): void
     {
-        $this->_init('emico_attributelanding_page', LandingPageInterface::PAGE_ID);
+        $this->_init('emico_attributelanding_page',LandingPageInterface::PAGE_ID);
     }
 
     /**

--- a/src/Model/ResourceModel/Page.php
+++ b/src/Model/ResourceModel/Page.php
@@ -34,7 +34,7 @@ class Page extends AbstractDb
      */
     protected function _construct(): void
     {
-        $this->_init('emico_attributelanding_page',LandingPageInterface::PAGE_ID);
+        $this->_init('emico_attributelanding_page', LandingPageInterface::PAGE_ID);
     }
 
     /**

--- a/src/Model/ResourceModel/Page/Collection.php
+++ b/src/Model/ResourceModel/Page/Collection.php
@@ -16,7 +16,7 @@ class Collection extends AbstractCollection
     /**
      * @var string
      */
-    protected $_idFieldName = 'page_id';
+    protected $_idFieldName = 'id';
 
     /**
      * @return void
@@ -24,5 +24,21 @@ class Collection extends AbstractCollection
     protected function _construct()
     {
         $this->_init(LandingPage::class, PageResourceModel::class);
+    }
+
+    /**
+     * Initialize select with join
+     *
+     * @return $this
+     */
+    protected function _initSelect()
+    {
+        parent::_initSelect();
+        $this->getSelect()->join(
+            ['emico_attributelanding_page_store' => $this->getTable('emico_attributelanding_page_store')],
+            'main_table.page_id = emico_attributelanding_page_store.page_id',
+            ['*']
+        );
+        return $this;
     }
 }

--- a/src/Model/UrlFinder.php
+++ b/src/Model/UrlFinder.php
@@ -142,8 +142,8 @@ class UrlFinder
         }
 
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter('emico_attributelanding_page_store.'.LandingPageInterface::ACTIVE, 1)
-            ->addFilter('emico_attributelanding_page_store.'.LandingPageInterface::FILTER_LINK_ALLOWED, 1)
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::ACTIVE, 1)
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::FILTER_LINK_ALLOWED, 1)
             ->create();
 
         $landingPageLookup = [];

--- a/src/Model/UrlFinder.php
+++ b/src/Model/UrlFinder.php
@@ -142,8 +142,8 @@ class UrlFinder
         }
 
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter(LandingPageInterface::ACTIVE, 1)
-            ->addFilter(LandingPageInterface::FILTER_LINK_ALLOWED, 1)
+            ->addFilter('emico_attributelanding_page_store.'.LandingPageInterface::ACTIVE, 1)
+            ->addFilter('emico_attributelanding_page_store.'.LandingPageInterface::FILTER_LINK_ALLOWED, 1)
             ->create();
 
         $landingPageLookup = [];

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -32,7 +32,7 @@
 		<dataProvider class="Emico\AttributeLanding\Model\Page\DataProvider" name="page_form_data_source">
 			<settings>
 				<requestFieldName>page_id</requestFieldName>
-				<primaryFieldName>page_id</primaryFieldName>
+				<primaryFieldName>main_table.page_id</primaryFieldName>
 			</settings>
 		</dataProvider>
 	</dataSource>


### PR DESCRIPTION
When you have an filter with an facet link enabled. The link to the ALP is not shown on the category page. This pull request fixes that.