### PR TITLE
Fix dont remove slash

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -164,7 +164,6 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
      */
     public function setUrlPath(?string $urlPath): LandingPageInterface
     {
-        $urlPath = trim($urlPath, ' /');
         return $this->setData(self::URL_PATH, $urlPath);
     }
 


### PR DESCRIPTION
The slash was previous removed to prevent issues with filters not working if the ALP url was the same as selected filters. This issue no longer exists in the current version. So the removal of the slash is no longer necessary.