### PR TITLE
Prevent URL suffix from being removed.

### DIFF
--- a/src/Model/UrlRewriteService.php
+++ b/src/Model/UrlRewriteService.php
@@ -235,8 +235,6 @@ class UrlRewriteService
             ? $page->getUrlRewriteRequestPath()
             : $page->getUrlPath() . $suffix;
 
-        $requestPath = trim($requestPath, '/');
-
         $urlRewrite->setRequestPath($requestPath);
 
         return $urlRewrite;


### PR DESCRIPTION
* When using the suffix "/" as a suffix it get's removed while some people do use the "/" as ending of a URL.