### PR TITLE
At the moment the Overview pages are not multi language compatible.

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -599,8 +599,6 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
             LandingPageInterface::NAME,
             LandingPageInterface::CREATED_AT,
             LandingPageInterface::UPDATED_AT,
-            LandingPageInterface::OVERVIEW_PAGE_ID,
-            LandingPageInterface::OVERVIEW_PAGE_IMAGE,
             LandingPageInterface::URL_PATH,
             LandingPageInterface::STORE_ID,
         ];
@@ -635,6 +633,8 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
             LandingPageInterface::FILTER_LINK_ALLOWED,
             LandingPageInterface::HIDE_SELECTED_FILTERS,
             LandingPageInterface::CANONICAL_URL,
+            LandingPageInterface::OVERVIEW_PAGE_ID,
+            LandingPageInterface::OVERVIEW_PAGE_IMAGE,
         ];
 
         return array_combine(

--- a/src/Model/LandingPageRepository.php
+++ b/src/Model/LandingPageRepository.php
@@ -284,8 +284,11 @@ class LandingPageRepository implements LandingPageRepositoryInterface
      */
     public function findAllByOverviewPage(OverviewPageInterface $overviewPage): array
     {
+        $storeId = $this->storeManager->getStore()->getId();
+
         $searchCriteria = $this->searchCriteriaBuilder
-            ->addFilter(LandingPageInterface::OVERVIEW_PAGE_ID, $overviewPage->getPageId())
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::OVERVIEW_PAGE_ID, $overviewPage->getPageId())
+            ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::STORE_ID, $storeId, 'in')
             ->addFilter('emico_attributelanding_page_store.' . LandingPageInterface::ACTIVE, 1)
             ->create();
 

--- a/src/Setup/Patch/Data/ConvertLandingpageEntries.php
+++ b/src/Setup/Patch/Data/ConvertLandingpageEntries.php
@@ -80,7 +80,9 @@ class ConvertLandingpageEntries implements DataPatchInterface
             LandingPageInterface::CANONICAL_URL,
             LandingPageInterface::HIDE_SELECTED_FILTERS,
             LandingPageInterface::TWEAKWISE_SORT_TEMPLATE,
-            LandingPageInterface::TWEAKWISE_BUILDER_TEMPLATE
+            LandingPageInterface::TWEAKWISE_BUILDER_TEMPLATE,
+            LandingPageInterface::OVERVIEW_PAGE_ID,
+            LandingPageInterface::OVERVIEW_PAGE_IMAGE,
         ];
 
         foreach ($fields as $field) {

--- a/src/etc/db_schema.xml
+++ b/src/etc/db_schema.xml
@@ -5,14 +5,9 @@
         <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" comment="Creation Time" default="CURRENT_TIMESTAMP" />
         <column xsi:type="timestamp" name="updated_at" on_update="true" nullable="false" comment="Update Time" default="CURRENT_TIMESTAMP" />
         <column xsi:type="varchar" name="url_path" nullable="false" comment="Url Path"/>
-        <column xsi:type="int" name="overview_page_id" nullable="true" unsigned="true" comment="Link to overview page"/>
         <column xsi:type="varchar" name="name" nullable="true" comment="Name"/>
-        <column xsi:type="varchar" name="overview_page_image" nullable="true" comment="Optional image to show on overview page"/>
         <constraint xsi:type="primary" referenceId="PRIMARY"><column name="page_id"/></constraint>
         <index referenceId="EMICO_ATTRIBUTELANDING_PAGE_URL_PATH" indexType="btree"><column name="url_path"/></index>
-        <constraint xsi:type="foreign" referenceId="EMICO_ATTRLANDING_PAGE_OVERVIEW_PAGE"
-                    table="emico_attributelanding_page" column="overview_page_id"
-                    referenceTable="emico_attributelanding_overviewpage" referenceColumn="page_id" onDelete="SET NULL"/>
     </table>
     <!-- Scoped Table: landingpage_store -->
     <table name="emico_attributelanding_page_store" resource="default" engine="innodb" comment="Landing Page Store Table">
@@ -36,11 +31,16 @@
         <column xsi:type="boolean" name="hide_selected_filters" nullable="true" default="1" comment="Whether to hide selected filters"/>
         <column xsi:type="int" name="tweakwise_sort_template" nullable="true" comment="Tweakwise sort template"/>
         <column xsi:type="int" name="tweakwise_builder_template" nullable="true" comment="Tweakwise builder template"/>
+        <column xsi:type="int" name="overview_page_id" nullable="true" unsigned="true" comment="Link to overview page"/>
+        <column xsi:type="varchar" name="overview_page_image" nullable="true" comment="Optional image to show on overview page"/>
         <constraint xsi:type="primary" referenceId="PRIMARY"><column name="id"/></constraint>
         <index referenceId="EMICO_ATTRIBUTELANDING_PAGE_URL_PATH_STORE" indexType="btree"><column name="url_path"/></index>
         <constraint xsi:type="unique" referenceId="UNQ_LANDINGPAGE_STORE_PAGE_ID_STORE_ID"><column name="page_id"/><column name="store_id"/></constraint>
         <constraint xsi:type="foreign" referenceId="FK_LANDINGPAGE_STORE_LANDINGPAGE_ID" table="emico_attributelanding_page_store" column="page_id" referenceTable="emico_attributelanding_page" referenceColumn="page_id" onDelete="CASCADE" />
         <constraint xsi:type="foreign" referenceId="FK_LANDINGPAGE_STORE_STORE_ID" table="emico_attributelanding_page_store" column="store_id" referenceTable="store" referenceColumn="store_id" onDelete="CASCADE" />
+        <constraint xsi:type="foreign" referenceId="EMICO_ATTRLANDING_PAGE_STORE_OVERVIEW_PAGE"
+                    table="emico_attributelanding_page_store" column="overview_page_id"
+                    referenceTable="emico_attributelanding_overviewpage" referenceColumn="page_id" onDelete="SET NULL"/>
     </table>
     <table name="emico_attributelanding_overviewpage" resource="default" engine="innodb" comment="Overview pages">
         <column xsi:type="int" name="page_id" unsigned="true" nullable="false" identity="true" comment="Autoincrement ID" />


### PR DESCRIPTION
By moving the columns overview_page_id / overview_page_image we can define this on store level which allows multi store language support.