### PR TITLE
fix: getLandingPage function public

### DIFF
--- a/src/Block/LandingPage/Content.php
+++ b/src/Block/LandingPage/Content.php
@@ -67,7 +67,7 @@ class Content extends Template
     /**
      * @return LandingPageInterface
      */
-    protected function getLandingPage(): LandingPageInterface
+    public function getLandingPage(): LandingPageInterface
     {
         return $this->landingPageContext->getLandingPage();
     }


### PR DESCRIPTION
We need this function in the frontend of the Tweakwise JS module. Therefore, it must be public instead of protected.