### PR TITLE
fix: Overview page image is deleted after page update

### DIFF
--- a/src/Controller/Adminhtml/Page/Save.php
+++ b/src/Controller/Adminhtml/Page/Save.php
@@ -133,7 +133,8 @@ class Save extends Action
             $data[LandingPageInterface::OVERVIEW_PAGE_IMAGE] =
                 $data[LandingPageInterface::OVERVIEW_PAGE_IMAGE][0]['file'];
         } else {
-            unset($data[LandingPageInterface::OVERVIEW_PAGE_IMAGE]);
+            $data[LandingPageInterface::OVERVIEW_PAGE_IMAGE] =
+                $data[LandingPageInterface::OVERVIEW_PAGE_IMAGE][0]['name'];
         }
 
         $filterAttributes = $data[LandingPageInterface::FILTER_ATTRIBUTES] ?? [];


### PR DESCRIPTION
Overview page image is getting deleted after update page.

Steps - 

1. Create attribute landing page with overview page image
2. Update any form field other that overview page image
3. After updating page check overview image - it is deleted