### PR TITLE
fix: sql error when chaning category url suffix setting

### DIFF
--- a/src/Model/UrlRewriteService.php
+++ b/src/Model/UrlRewriteService.php
@@ -94,7 +94,7 @@ class UrlRewriteService
         );
 
         $searchCriteria = $this->searchCriteriaBuilder->addFilter(
-            LandingPage::PAGE_ID,
+            'main_table.' . LandingPage::PAGE_ID,
             $landingPageIds,
             'in'
         )->create();


### PR DESCRIPTION
When changing the setting Stores->Configuration->Emico Extensions->attribute landing pages->Append Category url suffix to landingpage Urls and saving the changes you get an sql error.