### PR TITLE
fix: Save name on store level

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -596,7 +596,6 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
     {
         $fields = [
             LandingPageInterface::PAGE_ID,
-            LandingPageInterface::NAME,
             LandingPageInterface::CREATED_AT,
             LandingPageInterface::UPDATED_AT,
             LandingPageInterface::OVERVIEW_PAGE_ID,
@@ -604,6 +603,10 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
             LandingPageInterface::URL_PATH,
             LandingPageInterface::STORE_ID,
         ];
+
+        if ($this->getData(LandingPageInterface::STORE_ID) === 0) {
+            $fields[] = LandingPageInterface::NAME;
+        }
 
         return array_combine(
             $fields,
@@ -619,6 +622,7 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
         $fields = [
             LandingPageInterface::ACTIVE,
             LandingPageInterface::STORE_ID,
+            LandingPageInterface::NAME,
             LandingPageInterface::URL_PATH,
             LandingPageInterface::CATEGORY_ID,
             LandingPageInterface::HEADING,

--- a/src/Model/ResourceModel/Page.php
+++ b/src/Model/ResourceModel/Page.php
@@ -11,6 +11,7 @@ use Emico\AttributeLanding\Api\Data\LandingPageInterface;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Framework\Event\ManagerInterface as EventManager;
+use Zend_Db_Expr;
 
 class Page extends AbstractDb
 {
@@ -51,7 +52,7 @@ class Page extends AbstractDb
             ->join(
                 ['p' => $this->getTable('emico_attributelanding_page')],
                 'ps.page_id = p.page_id',
-                ['name']
+                ['name' => new Zend_Db_Expr('COALESCE(ps.name, p.name)')]
             )
             ->where('ps.page_id = ?', $landingPageId)
             ->where('store_id = ?', $storeId);

--- a/src/etc/db_schema.xml
+++ b/src/etc/db_schema.xml
@@ -20,6 +20,7 @@
         <column name="page_id" xsi:type="int" nullable="false" unsigned="true" comment="Landing Page ID" />
         <column name="store_id" xsi:type="smallint" nullable="false" unsigned="true" comment="Store ID" />
         <column xsi:type="boolean" name="active" nullable="true" default="1" comment="Active state" />
+        <column xsi:type="varchar" name="name" nullable="true" comment="Name"/>
         <column xsi:type="varchar" name="url_path" nullable="false" comment="Url Path"/>
         <column xsi:type="int" name="category_id" unsigned="true" nullable="true" comment="Category Id"/>
         <column xsi:type="varchar" name="heading" nullable="true" comment="H2 Heading"/>

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_form.xml
@@ -97,6 +97,10 @@
 			<argument name="data" xsi:type="array">
 				<item name="config" xsi:type="array">
 					<item name="source" xsi:type="string">Page</item>
+                    <item name="scopeLabel" xsi:type="string">[STORE VIEW]</item>
+                    <item name="showInDefault" xsi:type="boolean">1</item>
+                    <item name="showInWebsite" xsi:type="boolean">0</item>
+                    <item name="showInStore" xsi:type="boolean">1</item>
 				</item>
 			</argument>
 			<settings>


### PR DESCRIPTION
Save the name of the landingpage on store level instead of page level.