### PR TITLE
Fix: Fixed issue when category suffix is configured as slash

### DIFF
--- a/src/Model/UrlRewriteService.php
+++ b/src/Model/UrlRewriteService.php
@@ -11,7 +11,9 @@ use Emico\AttributeLanding\Api\Data\LandingPageInterface;
 use Emico\AttributeLanding\Api\LandingPageRepositoryInterface;
 use Emico\AttributeLanding\Api\UrlRewriteGeneratorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
@@ -58,6 +60,7 @@ class UrlRewriteService
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param UrlFinderInterface $urlFinder
      * @param LandingPageRepositoryInterface $landingPageRepository
+     * @param Config $config
      */
     public function __construct(
         UrlRewriteFactory $urlRewriteFactory,
@@ -65,7 +68,8 @@ class UrlRewriteService
         UrlPersistInterface $urlPersist,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         UrlFinderInterface $urlFinder,
-        LandingPageRepositoryInterface $landingPageRepository
+        LandingPageRepositoryInterface $landingPageRepository,
+        private readonly Config $config,
     ) {
         $this->urlRewriteFactory = $urlRewriteFactory;
         $this->storeManager = $storeManager;
@@ -244,11 +248,29 @@ class UrlRewriteService
             ? $page->getUrlRewriteRequestPath()
             : $page->getUrlPath() . $suffix; // @phpstan-ignore-line
 
-        $requestPath = trim($requestPath, '/');
+        if ($this->shouldStripRequestPath($suffix)) {
+            $requestPath = trim($requestPath, '/');
+        }
 
         $urlRewrite->setRequestPath($requestPath);
 
         return $urlRewrite;
+    }
+
+    /**
+     * @param string|null $newSuffix
+     * @return bool
+     * @throws NoSuchEntityException
+     */
+    private function shouldStripRequestPath(?string $newSuffix): bool
+    {
+        /** @var Store $store */
+        $store = $this->storeManager->getStore();
+        $suffix = $newSuffix ?? $this->config->getCategoryUrlSuffix($store);
+        return !(
+            $suffix === '/' &&
+            $this->config->isAppendCategoryUrlSuffix($store)
+        );
     }
 
     protected function getActiveStoreIds(UrlRewriteGeneratorInterface $landingPage): array


### PR DESCRIPTION
The trailing slash was always trimmed from the URL rewrite, even when a slash was set as the category suffix. This is now checked for proper slash trimming. If the suffix is ​​set to a slash, it will not be trimmed from the URL rewrite.

**Steps to reproduce the bug:**
1. Set the `Stores -> Configuration -> Catalog -> Catalog -> Search Engine Optimization -> Category URL Suffix` configuration to `/`
2. Set the `Stores -> Configuration -> Emico Extensions -> Attribute landing pages -> General -> Append Category url suffix to landingpage Urls` configuration to `Yes`
3. Create an attribute landing page 
4. Go in the admin to `Marketing -> URL Rewrites` and search for your attribute landing page URL rewrites. 
5. Check if the request path of the URL rewrites does NOT contain a trailing slash, even though you have set it to do so

**Test scenario after bugfix:**
1. Make sure configurations are set correctly as described above
2. Create an attribute landing page 
3. Go in the admin to `Marketing -> URL Rewrites` and search for your attribute landing page URL rewrites. 
4. Check if the request path of the URL rewrites does contain a trailing slash
5. Change the `Category URL Suffix` to `.html`
6. Check if trailing slash is changed to .html in the URL rewrites
7. Change the `Category URL Suffix` back to `/`
8. Check if `.html` is changed to `/` in the URL rewrites