### PR TITLE
fix: Add admin URL to DataProvider config data

### DIFF
--- a/src/Controller/Adminhtml/Page/Save.php
+++ b/src/Controller/Adminhtml/Page/Save.php
@@ -160,7 +160,7 @@ class Save extends Action
      */
     protected function sanitizeFilterAttributes(array $filterAttributes): array
     {
-        $allowedFields = ['attribute', 'value'];
+        $allowedFields = ['attribute', 'value', 'attribute_other', 'attribute_value_other'];
         $sanitizedAttributes = [];
         foreach ($filterAttributes as $filterAttribute) {
             foreach (array_keys($filterAttribute) as $field) {

--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -356,9 +356,17 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
     /**
      * @return array
      */
+    public function getFrontendFilterAttributes(): array
+    {
+        return $this->getUnserializedFilterAttributes();
+    }
+
+    /**
+     * @return array
+     */
     public function getFilters(): array
     {
-        $unserializedFilters = $this->getUnserializedFilterAttributes();
+        $unserializedFilters = $this->getFrontendFilterAttributes();
         /** @phpstan-ignore-next-line */
         if (!is_array($unserializedFilters)) {
             return [];

--- a/src/Model/Page/DataProvider.php
+++ b/src/Model/Page/DataProvider.php
@@ -11,6 +11,8 @@ use Emico\AttributeLanding\Api\Data\LandingPageInterface;
 use Emico\AttributeLanding\Model\LandingPageRepository;
 use Emico\AttributeLanding\Model\ResourceModel\Page\Collection;
 use Emico\AttributeLanding\Model\ResourceModel\Page\CollectionFactory;
+use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\Backend\Model\UrlInterface;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Ui\DataProvider\AbstractDataProvider;
@@ -48,6 +50,8 @@ class DataProvider extends AbstractDataProvider
      * @param ImageUploader $imageUploader
      * @param Http $request
      * @param LandingPageRepository $landingPageRepository
+     * @param FrontNameResolver $frontNameResolver
+     * @param UrlInterface $backendUrl
      * @param array $meta
      * @param array $data
      * @SuppressWarnings("PHPMD.ExcessiveParameterList")
@@ -61,6 +65,8 @@ class DataProvider extends AbstractDataProvider
         ImageUploader $imageUploader,
         private readonly Http $request,
         private readonly LandingPageRepository $landingPageRepository,
+        private readonly FrontNameResolver $frontNameResolver,
+        private readonly UrlInterface $backendUrl,
         array $meta = [],
         array $data = []
     ) {
@@ -120,5 +126,20 @@ class DataProvider extends AbstractDataProvider
         }
 
         return $this->loadedData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getConfigData()
+    {
+        $configData = parent::getConfigData();
+        $configData['admin_url'] = sprintf(
+            '%s%s/',
+            $this->backendUrl->getBaseUrl(),
+            $this->frontNameResolver->getFrontName()
+        );
+
+        return $configData;
     }
 }

--- a/src/Model/Page/DataProvider.php
+++ b/src/Model/Page/DataProvider.php
@@ -129,7 +129,7 @@ class DataProvider extends AbstractDataProvider
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getConfigData()
     {


### PR DESCRIPTION
Added admin URL to DataProvider config data, because it will be used in https://github.com/EmicoEcommerce/Magento2AttributeLandingTweakwise/pull/52