### PR TITLE
fix: rest api schema

### DIFF
--- a/src/Api/Data/LandingPageInterface.php
+++ b/src/Api/Data/LandingPageInterface.php
@@ -167,7 +167,7 @@ interface LandingPageInterface extends ExtensibleDataInterface
     public function getFilters(): array;
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getUnserializedFilterAttributes(): array;
 

--- a/src/etc/webapi.xml
+++ b/src/etc/webapi.xml
@@ -12,8 +12,8 @@
 			<resource ref="Emico_AttributeLanding::Page_view"/>
 		</resources>
 	</route>
-	<route method="GET" url="/V1/emico-attributelanding/page/:pageId">
-		<service class="Emico\AttributeLanding\Api\LandingPageRepositoryInterface" method="getById"/>
+	<route method="GET" url="/V1/emico-attributelanding/page/:pageId/:storeId">
+		<service class="Emico\AttributeLanding\Api\LandingPageRepositoryInterface" method="getByIdWithStore"/>
 		<resources>
 			<resource ref="Emico_AttributeLanding::Page_view"/>
 		</resources>


### PR DESCRIPTION
## Description

This Pull Request resolves a error during REST API schema generation (`/rest/all/schema?services=all`) specifically encountered when the **Tweakwise ALP (Advanced Landing Pages)** module is enabled. 

---

## How to Test

1. **Environment Setup:** Ensure the `ALP` module is active
2. **Reproduce the Error:** * Execute a GET request to the schema endpoint: `{{base_url}}/rest/all/schema?services=all`
   * **Result before fix:** The request fails with a 500 Error or a reflection-related PHP Fatal Error.
3. **Apply Fix & Verify:**
   * Apply the changes from this PR.
   * Clear the cache: `bin/magento cache:flush`.
   * Re-run the GET request to the schema endpoint.
   * **Result after fix:** The endpoint should return a valid **200 OK** response with the full JSON/Swagger schema.
4. **Regression Check:** Visit a Tweakwise-driven landing page on the storefront to confirm that standard catalog and search functionality remains unaffected.