### PR TITLE
Fix: add db schema json

### DIFF
--- a/src/etc/db_schema_whitelist.json
+++ b/src/etc/db_schema_whitelist.json
@@ -1,0 +1,102 @@
+{
+    "emico_attributelanding_page": {
+        "column": {
+            "page_id": true,
+            "created_at": true,
+            "updated_at": true,
+            "url_path": true,
+            "overview_page_id": true,
+            "name": true,
+            "overview_page_image": true
+        },
+        "index": {
+            "EMICO_ATTRIBUTELANDING_PAGE_URL_PATH": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "FK_A8661B1DD183E5D311907AF672A5EBB6": true
+        }
+    },
+    "emico_attributelanding_page_store": {
+        "column": {
+            "id": true,
+            "page_id": true,
+            "store_id": true,
+            "active": true,
+            "name": true,
+            "url_path": true,
+            "category_id": true,
+            "heading": true,
+            "header_image": true,
+            "meta_title": true,
+            "meta_keywords": true,
+            "meta_description": true,
+            "content_first": true,
+            "content_last": true,
+            "filter_attributes": true,
+            "tweakwise_filter_template": true,
+            "is_filter_link_allowed": true,
+            "canonical_url": true,
+            "hide_selected_filters": true,
+            "tweakwise_sort_template": true,
+            "tweakwise_builder_template": true
+        },
+        "index": {
+            "EMICO_ATTRIBUTELANDING_PAGE_STORE_URL_PATH": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "EMICO_ATTRIBUTELANDING_PAGE_STORE_PAGE_ID_STORE_ID": true,
+            "FK_3277887D3FFBCA6335B0722410074EC8": true,
+            "EMICO_ATTRIBUTELANDING_PAGE_STORE_STORE_ID_STORE_STORE_ID": true
+        }
+    },
+    "emico_attributelanding_overviewpage": {
+        "column": {
+            "page_id": true,
+            "active": true,
+            "created_at": true,
+            "updated_at": true,
+            "url_path": true,
+            "heading": true,
+            "meta_title": true,
+            "meta_keywords": true,
+            "meta_description": true,
+            "content_first": true,
+            "content_last": true,
+            "store_ids": true,
+            "name": true
+        },
+        "index": {
+            "EMICO_ATTRIBUTELANDING_OVERVIEWPAGE_URL_PATH": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        }
+    },
+    "emico_attributelanding_overviewpage_store": {
+        "column": {
+            "id": true,
+            "page_id": true,
+            "store_id": true,
+            "name": true,
+            "active": true,
+            "url_path": true,
+            "heading": true,
+            "meta_title": true,
+            "meta_keywords": true,
+            "meta_description": true,
+            "content_first": true,
+            "content_last": true
+        },
+        "index": {
+            "EMICO_ATTRIBUTELANDING_OVERVIEWPAGE_STORE_URL_PATH": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "EMICO_ATTRIBUTELANDING_OVERVIEWPAGE_STORE_PAGE_ID_STORE_ID": true,
+            "FK_B7EFA6127C42BC761B70AF51B95F160D": true,
+            "EMICO_ATTRLANDING_OVERVIEWPAGE_STORE_STORE_ID_STORE_STORE_ID": true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

New version of #119 

- Added `src/etc/db_schema_whitelist.json`, generated via `bin/magento setup:db-declaration:generate-whitelist`
- The whitelist registers all existing tables, columns, indexes, and constraints that were already declared in `db_schema.xml`
- No database changes are made; this file is purely metadata consumed by Magento's declarative schema system

## How to test

**Scenario 1 — No impact on existing installs**

1. Check out this branch on an existing Magento install that already has the `emico_attributelanding_*` tables.
2. Run `bin/magento setup:upgrade`.
3. Verify no ALTER, DROP, or CREATE statements are executed against the `emico_attributelanding_*` tables.
4. Confirm the site operates normally.

---

**Scenario 2 — Fresh install**

1. Check out this branch on a clean Magento install without the module's tables.
2. Run `bin/magento setup:upgrade`.
3. Verify all four tables are created: `emico_attributelanding_page`, `emico_attributelanding_page_store`, `emico_attributelanding_overviewpage`, `emico_attributelanding_overviewpage_store`.
4. Confirm landing pages can be created and viewed in the admin.