### PR TITLE
feat: add url and name to alp admin overview

### DIFF
--- a/src/Model/ResourceModel/Page/Collection.php
+++ b/src/Model/ResourceModel/Page/Collection.php
@@ -27,8 +27,6 @@ class Collection extends AbstractCollection
     }
 
     /**
-     * Initialize select with join
-     *
      * @return $this
      */
     protected function _initSelect()

--- a/src/Model/ResourceModel/Page/Grid/Collection.php
+++ b/src/Model/ResourceModel/Page/Grid/Collection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Emico\AttributeLanding\Model\ResourceModel\Page\Grid;
 
+use Magento\Framework\DB\Select;
 use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
 use Zend_Db_Expr;
 
@@ -34,6 +35,31 @@ class Collection extends SearchResult
             )
             ->group('main_table.page_id');
         return parent::_beforeLoad();
+    }
+
+    /**
+     * Override the count SELECT to include the store join and GROUP BY when a HAVING
+     * clause is present, so GROUP_CONCAT aggregate filters work correctly during pagination.
+     *
+     * @return Select
+     */
+    public function getSelectCountSql()
+    {
+        $countSelect = parent::getSelectCountSql();
+
+        $having = $countSelect->getPart(Select::HAVING);
+        if (empty($having)) {
+            return $countSelect;
+        }
+
+        $countSelect->joinLeft(
+            ['emico_attributelanding_page_store' => $this->getTable('emico_attributelanding_page_store')],
+            'main_table.page_id = emico_attributelanding_page_store.page_id',
+            []
+        );
+        $countSelect->group('main_table.page_id');
+
+        return $this->getConnection()->select()->from($countSelect, [new Zend_Db_Expr('COUNT(*)')]);
     }
 
     /**

--- a/src/Model/ResourceModel/Page/Grid/Collection.php
+++ b/src/Model/ResourceModel/Page/Grid/Collection.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Emico\AttributeLanding\Model\ResourceModel\Page\Grid;
+
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
+use Psr\Log\LoggerInterface;
+use Zend_Db_Expr;
+
+class Collection extends SearchResult
+{
+    /**
+     * Add the store URL and store name aggregation just before the collection loads,
+     * after SearchResult has finished setting up its base SELECT.
+     *
+     * @return $this
+     */
+    protected function _beforeLoad()
+    {
+        $this->getSelect()
+            ->joinLeft(
+                ['emico_attributelanding_page_store' => $this->getTable('emico_attributelanding_page_store')],
+                'main_table.page_id = emico_attributelanding_page_store.page_id',
+                [
+                    'store_urls' => new Zend_Db_Expr(
+                        'GROUP_CONCAT(DISTINCT CONCAT(emico_attributelanding_page_store.store_id, \':\', emico_attributelanding_page_store.url_path) '
+                        . 'ORDER BY emico_attributelanding_page_store.store_id SEPARATOR \',\')'
+                    ),
+                    'name' => new Zend_Db_Expr(
+                        'GROUP_CONCAT(DISTINCT CONCAT(emico_attributelanding_page_store.store_id, \':\', emico_attributelanding_page_store.name) '
+                        . 'ORDER BY emico_attributelanding_page_store.store_id SEPARATOR \',\')'
+                    ),
+                ]
+            )
+            ->group('main_table.page_id');
+        return parent::_beforeLoad();
+    }
+
+    /**
+     * Intercept store_urls and name filters and apply them as HAVING clauses so they
+     * work against the GROUP_CONCAT aggregates instead of raw columns.
+     *
+     * @param string|array $field
+     * @param mixed $condition
+     * @return $this
+     */
+    public function addFieldToFilter($field, $condition = null)
+    {
+        if ($field === 'store_urls') {
+            $value = is_array($condition) ? ($condition['like'] ?? reset($condition)) : $condition;
+            $value = trim((string) $value, '%');
+            $this->getSelect()->having(
+                'GROUP_CONCAT(DISTINCT CONCAT(emico_attributelanding_page_store.store_id, \':\', emico_attributelanding_page_store.url_path) ORDER BY emico_attributelanding_page_store.store_id SEPARATOR \',\') LIKE ?',
+                '%' . $value . '%'
+            );
+            return $this;
+        }
+
+        if ($field === 'name') {
+            $value = is_array($condition) ? ($condition['like'] ?? reset($condition)) : $condition;
+            $value = trim((string) $value, '%');
+            $this->getSelect()->having(
+                'GROUP_CONCAT(DISTINCT CONCAT(emico_attributelanding_page_store.store_id, \':\', emico_attributelanding_page_store.name) ORDER BY emico_attributelanding_page_store.store_id SEPARATOR \',\') LIKE ?',
+                '%' . $value . '%'
+            );
+            return $this;
+        }
+
+        return parent::addFieldToFilter($field, $condition);
+    }
+}

--- a/src/Model/ResourceModel/Page/Grid/Collection.php
+++ b/src/Model/ResourceModel/Page/Grid/Collection.php
@@ -4,13 +4,7 @@ declare(strict_types=1);
 
 namespace Emico\AttributeLanding\Model\ResourceModel\Page\Grid;
 
-use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
-use Magento\Framework\Data\Collection\EntityFactoryInterface;
-use Magento\Framework\DB\Adapter\AdapterInterface;
-use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
-use Psr\Log\LoggerInterface;
 use Zend_Db_Expr;
 
 class Collection extends SearchResult

--- a/src/Ui/Component/Listing/Column/StoreUrls.php
+++ b/src/Ui/Component/Listing/Column/StoreUrls.php
@@ -46,12 +46,12 @@ class StoreUrls extends Column
             $storeNames[(int) $store->getId()] = $store->getName();
         }
 
-        foreach ($dataSource['data']['items'] as &$item) {
-            $columnName = $this->getData('name');
-            $raw = $item[$columnName] ?? '';
+        $columnName = $this->getData('name');
+        foreach (array_keys($dataSource['data']['items']) as $index) {
+            $raw = $dataSource['data']['items'][$index][$columnName] ?? '';
 
             if ($raw === '' || $raw === null) {
-                $item[$columnName] = '';
+                $dataSource['data']['items'][$index][$columnName] = '';
                 continue;
             }
 
@@ -67,7 +67,7 @@ class StoreUrls extends Column
                 $lines[] = sprintf('%s: %s', $storeName, $urlPath);
             }
 
-            $item[$columnName] = implode('<br/>', $lines);
+            $dataSource['data']['items'][$index][$columnName] = implode('<br/>', $lines);
         }
 
         return $dataSource;

--- a/src/Ui/Component/Listing/Column/StoreUrls.php
+++ b/src/Ui/Component/Listing/Column/StoreUrls.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Emico\AttributeLanding\Ui\Component\Listing\Column;
+
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class StoreUrls extends Column
+{
+    /**
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param StoreRepositoryInterface $storeRepository
+     * @param array $components
+     * @param array $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        private readonly StoreRepositoryInterface $storeRepository,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    /**
+     * Prepare Data Source by replacing the raw store_urls string with a human-readable list.
+     *
+     * @param array $dataSource
+     * @return array
+     */
+    public function prepareDataSource(array $dataSource): array
+    {
+        if (!isset($dataSource['data']['items'])) {
+            return $dataSource;
+        }
+
+        $stores = $this->storeRepository->getList();
+        $storeNames = [];
+        foreach ($stores as $store) {
+            $storeNames[(int) $store->getId()] = $store->getName();
+        }
+
+        foreach ($dataSource['data']['items'] as &$item) {
+            $columnName = $this->getData('name');
+            $raw = $item[$columnName] ?? '';
+
+            if ($raw === '' || $raw === null) {
+                $item[$columnName] = '';
+                continue;
+            }
+
+            $lines = [];
+            foreach (explode(',', (string) $raw) as $entry) {
+                $parts = explode(':', $entry, 2);
+                if (count($parts) !== 2) {
+                    continue;
+                }
+                [$storeId, $urlPath] = $parts;
+                $storeId = (int) $storeId;
+                $storeName = $storeId === 0 ? __('Global') : ($storeNames[$storeId] ?? __('Store %1', $storeId));
+                $lines[] = sprintf('%s: %s', $storeName, $urlPath);
+            }
+
+            $item[$columnName] = implode('<br/>', $lines);
+        }
+
+        return $dataSource;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -19,15 +19,14 @@
                 type="Emico\AttributeLanding\Model\FilterHider\MagentoFilterHider"/>
     <preference for="Magento\Catalog\Block\Breadcrumbs" type="Emico\AttributeLanding\Block\Catalog\Breadcrumbs"/>
 
-    <virtualType name="Emico\AttributeLanding\Model\ResourceModel\Page\Grid\Collection"
-                 type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+    <type name="Emico\AttributeLanding\Model\ResourceModel\Page\Grid\Collection">
         <arguments>
             <argument name="mainTable" xsi:type="string">emico_attributelanding_page</argument>
             <argument name="resourceModel" xsi:type="string">
                 Emico\AttributeLanding\Model\ResourceModel\Page\Collection
             </argument>
         </arguments>
-    </virtualType>
+    </type>
 
     <virtualType name="Emico\AttributeLanding\Model\ResourceModel\OverviewPage\Grid\Collection"
                  type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">

--- a/src/view/adminhtml/ui_component/emico_attributelanding_page_listing.xml
+++ b/src/view/adminhtml/ui_component/emico_attributelanding_page_listing.xml
@@ -84,10 +84,12 @@
                 <label translate="true">ID</label>
             </settings>
         </column>
-        <column name="name" sortOrder="35">
+        <column class="Emico\AttributeLanding\Ui\Component\Listing\Column\StoreUrls" name="name" sortOrder="35">
             <settings>
                 <filter>text</filter>
                 <label translate="true">Name</label>
+                <sortable>false</sortable>
+                <bodyTmpl>ui/grid/cells/html</bodyTmpl>
             </settings>
         </column>
         <column name="created_at" sortOrder="47">
@@ -100,6 +102,14 @@
             <settings>
                 <filter>text</filter>
                 <label translate="true">Updated at</label>
+            </settings>
+        </column>
+        <column class="Emico\AttributeLanding\Ui\Component\Listing\Column\StoreUrls" name="store_urls" sortOrder="49">
+            <settings>
+                <label translate="true">Store URLs</label>
+                <sortable>false</sortable>
+                <filter>text</filter>
+                <bodyTmpl>ui/grid/cells/html</bodyTmpl>
             </settings>
         </column>
         <actionsColumn class="Emico\AttributeLanding\Ui\Component\Listing\Column\PageActions" name="actions" sortOrder="50">


### PR DESCRIPTION
## Summary

- Adds a **Store URLs** column to the landing page admin grid, showing each store's URL path prefixed with the store name (e.g. `Global: my-landing-page`). Store ID `0` is labelled `Global`.
- Replaces the **Name** column with store-scoped names from `emico_attributelanding_page_store`, rendered with the same `store_id` prefix as the URL column.
- Both columns are **searchable** via a `HAVING GROUP_CONCAT(...) LIKE ?` clause, avoiding issues with aggregate expressions in `WHERE`.
- Fixes a pre-existing bug where the grid showed **one row per store per page** (due to an inner join in `Page\Collection`); the grid now always shows **one row per landing page** with all store values grouped.
- Introduces `Model\ResourceModel\Page\Grid\Collection`, a dedicated grid collection extending `SearchResult`, keeping grid-specific query logic isolated from the general-purpose `Page\Collection` used on the frontend.

## How to test

**Scenario 1 — Store URLs and Names are visible**

1. Go to **Content > Landing Pages** in the admin.
2. Confirm the grid shows a **Name** column and a **Store URLs** column.
3. For a landing page configured on multiple stores, confirm both columns show one line per store prefixed with the store name (e.g. `Global: my-url`, `Default Store View: my-url`).
4. For a landing page with only a global (`store_id = 0`) row, confirm the prefix reads `Global`.

---

**Scenario 2 — One row per landing page**

1. Create a landing page and save it for at least two store views.
2. Open the landing page grid.
3. Confirm the page appears **once** in the grid, not once per store.

---

**Scenario 3 — Searching on Store URLs**

1. In the **Store URLs** filter field at the top of the grid, type part of a known URL path.
2. Confirm only matching landing pages are returned.
3. Confirm no SQL error occurs and pagination works correctly.

---

**Scenario 4 — Searching on Name**

1. In the **Name** filter field, type part of a known landing page name.
2. Confirm only matching landing pages are returned.
3. Confirm no SQL error occurs and pagination works correctly.

---

**Scenario 5 — Frontend is unaffected**

1. Visit a landing page URL on the storefront (e.g. `https://magento2.test/default/women/tops-women2/`).
2. Confirm the page loads correctly with filters applied as before.
3. Confirm no regression in URL matching or filter behaviour.

---