### PR TITLE
Fix: alp name

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -611,10 +611,9 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
             LandingPageInterface::OVERVIEW_PAGE_ID,
             LandingPageInterface::OVERVIEW_PAGE_IMAGE,
             LandingPageInterface::URL_PATH,
-            LandingPageInterface::STORE_ID,
         ];
 
-        if ($this->getData(LandingPageInterface::STORE_ID) === 0) {
+        if ((int) $this->getData(LandingPageInterface::STORE_ID) === 0) {
             $fields[] = LandingPageInterface::NAME;
         }
 


### PR DESCRIPTION
## Summary

- Removes `STORE_ID` from the field list returned by `getLandingPageDataWithoutStore()`. The `emico_attributelanding_page` table has no `store_id` column; passing it to Magento's ORM `save()` caused the adapter to silently discard or error on the unknown column, which could corrupt the global-table row.
- Fixes a strict-type comparison bug in the same method: `$this->getData(...)` returns a `string` from the model's internal data bag, so `=== 0` (strict, integer) always evaluated to `false`. As a result the `name` column in `emico_attributelanding_page` was never populated, even for the default store scope (`store_id = 0`). Cast to `(int)` before the strict comparison to restore the intended behaviour.
- Resolves #129 — after upgrading to 6.0.1, key fields appeared empty in `emico_attributelanding_page` because the two-step save in `LandingPageRepository::save()` was writing a broken global-table row.

## How to test

**Scenario 1 — Default store scope: name is saved to the global table**

1. Go to **Content → Landing Pages → Add New Page**.
2. With store scope set to **All Store Views** (`store_id = 0`), fill in the **Name**, **URL Path**, and **Category** fields, then save.
3. Open a database client and run:

       SELECT page_id, name, url_path FROM emico_attributelanding_page ORDER BY page_id DESC LIMIT 1;

4. Confirm `name` and `url_path` are populated (previously `name` was always `NULL`).
5. Also verify `store_id` is **not** a column in the result set (it does not exist on this table).

---

**Scenario 2 — Store-specific scope: name is not written to the global table**

1. Edit the same page, switch the store scope to a specific store view, change the **Name**, and save.
2. Re-run the query from Scenario 1.
3. Confirm the `name` column in `emico_attributelanding_page` is unchanged (store-scoped name lives only in `emico_attributelanding_page_store`).
4. Run:

       SELECT page_id, store_id, name, category_id FROM emico_attributelanding_page_store ORDER BY id DESC LIMIT 3;

5. Confirm the store-specific row has the correct `name` and `category_id`.

---

**Scenario 3 — Frontend landing page resolves correctly**

1. Visit the landing page URL on the storefront.
2. Confirm the page loads, the correct category is used to drive the product listing, and no 404 or blank-page error occurs.
3. Repeat for both the default store scope and a specific store view.

---