### PR TITLE
Fix: unserialize error

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -12,6 +12,7 @@ use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\AbstractExtensibleModel;
 use Magento\Framework\Registry;
 use Magento\Framework\Model\Context;
+use Exception;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 
 /**
@@ -353,7 +354,7 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
 
         try {
             $result = unserialize($raw, ['allowed_classes' => false]);
-        } catch (\Throwable $e) {
+        } catch (Exception $e) {
             return [];
         }
 

--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -346,11 +346,22 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
      */
     public function getUnserializedFilterAttributes(): array
     {
-        if ($this->getFilterAttributes() === null) {
+        $raw = $this->getFilterAttributes();
+        if ($raw === null || $raw === '') {
             return [];
         }
 
-        return unserialize($this->getFilterAttributes());
+        try {
+            $result = unserialize($raw, ['allowed_classes' => false]);
+        } catch (\Throwable $e) {
+            return [];
+        }
+
+        if (!is_array($result)) {
+            return [];
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Model/UrlFinder.php
+++ b/src/Model/UrlFinder.php
@@ -10,6 +10,7 @@ namespace Emico\AttributeLanding\Model;
 use Emico\AttributeLanding\Api\Data\FilterInterface;
 use Emico\AttributeLanding\Api\Data\LandingPageInterface;
 use Emico\AttributeLanding\Api\LandingPageRepositoryInterface;
+use Exception;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
@@ -152,7 +153,7 @@ class UrlFinder
         foreach ($this->landingPageRepository->getList($searchCriteria)->getItems() as $landingPage) {
             try {
                 $filters = $landingPage->getFilters();
-            } catch (\Throwable $e) {
+            } catch (Exception $e) {
                 continue;
             }
 

--- a/src/Model/UrlFinder.php
+++ b/src/Model/UrlFinder.php
@@ -150,7 +150,13 @@ class UrlFinder
 
         $landingPageLookup = [];
         foreach ($this->landingPageRepository->getList($searchCriteria)->getItems() as $landingPage) {
-            $hash = $this->createHashForFilters($landingPage->getFilters(), $landingPage->getCategoryId());
+            try {
+                $filters = $landingPage->getFilters();
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            $hash = $this->createHashForFilters($filters, $landingPage->getCategoryId());
             /** @phpstan-ignore-next-line */
             $storeId = $landingPage->getData('store_id');
             /** @phpstan-ignore-next-line */


### PR DESCRIPTION
## Summary

- **Fixes constant DB queries on every request** caused by `UrlFinder::loadPageLookupArray()` never successfully populating its cache entry. The root cause was that `LandingPage::getUnserializedFilterAttributes()` called `unserialize()` without error handling. On PHP 8.x, malformed or truncated `filter_attributes` rows trigger a `Warning` that Magento's `ErrorHandler` converts into a thrown `Exception`. This exception escaped the `foreach` loop in `loadPageLookupArray()`, preventing `$this->cache->save()` from ever being reached. On every new request (new worker/process) the in-memory guard was `null` again, so the heavy `emico_attributelanding_page` JOIN query ran unconditionally.
- **Fixes `unserialize(): Error at offset` warnings** (issue #135) by wrapping `unserialize()` in a `try/catch (\Throwable)` and validating the result is an array. Corrupt or legacy rows now return `[]` instead of throwing. `['allowed_classes' => false]` is also added as a security hardening measure.
- **Adds a per-iteration guard in `UrlFinder::loadPageLookupArray()`** so that if any single landing page's `getFilters()` call throws for any future reason, that page is skipped and the rest of the lookup array is still built and cached normally.

## How to test

**Scenario 1 — Normal operation: cache is populated and reused**

1. Ensure at least one active landing page exists with valid `filter_attributes`.
2. Enable query logging (e.g. MySQL general log or a profiler toolbar).
3. Load a category page that has layered navigation.
4. Verify the `emico_attributelanding_page` JOIN query runs exactly once.
5. Reload the page; verify the query does **not** run again (cache hit).
6. Save the landing page in the admin; reload the category page and verify the query runs once more (cache invalidated by `InvalidateCacheObserver`), then is cached again on the next load.

---

**Scenario 2 — Corrupt `filter_attributes` row: graceful degradation, cache still populated**

1. Directly update a landing page row in the database to set `filter_attributes` to a malformed string, e.g.:
   ```sql
   UPDATE emico_attributelanding_page SET filter_attributes = 'CORRUPTED' WHERE page_id = <id>;
   ```
2. Flush the Magento cache (`bin/magento cache:clean`).
3. Load a category page with layered navigation.
4. Verify **no** `unserialize` warning or exception appears in `var/log/exception.log`.
5. Verify the corrupted landing page is silently skipped; all other valid landing pages are still present in the lookup and their filter links render correctly.
6. Verify the JOIN query runs only once per cache lifetime (cache was successfully populated despite the corrupt row).

---

**Scenario 3 — Admin form renders correctly for corrupt row**

1. With the corrupt row from Scenario 2 still in place, open the landing page edit form in the admin.
2. Verify the page loads without a 500 error.
3. Verify the `filter_attributes` dynamic rows field is empty (reflecting what is actually stored).
4. Save the form with valid filter attributes; verify the row is repaired and the frontend lookup works correctly afterwards.

---