### PR TITLE
Fix: empty name

### DIFF
--- a/src/Model/LandingPage.php
+++ b/src/Model/LandingPage.php
@@ -136,7 +136,7 @@ class LandingPage extends AbstractExtensibleModel implements LandingPageInterfac
      */
     public function getName(): string
     {
-        return $this->getData(self::NAME);
+        return $this->getData(self::NAME) ?? '';
     }
 
     /**

--- a/src/Setup/Patch/Data/ConvertLandingpageEntries.php
+++ b/src/Setup/Patch/Data/ConvertLandingpageEntries.php
@@ -62,6 +62,7 @@ class ConvertLandingpageEntries implements DataPatchInterface
         ];
 
         $fields = [
+            LandingPageInterface::NAME,
             LandingPageInterface::ACTIVE,
             LandingPageInterface::URL_PATH,
             LandingPageInterface::CATEGORY_ID,

--- a/src/Setup/Patch/Data/FixLandingPageStoreName.php
+++ b/src/Setup/Patch/Data/FixLandingPageStoreName.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Emico\AttributeLanding\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+class FixLandingPageStoreName implements DataPatchInterface
+{
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        private readonly ModuleDataSetupInterface $moduleDataSetup,
+    ) {
+    }
+
+    /**
+     * Back-fill the name column in emico_attributelanding_page_store for rows
+     * that were inserted by ConvertLandingpageEntries without the name field.
+     *
+     * @return $this
+     */
+    public function apply(): FixLandingPageStoreName
+    {
+        $this->moduleDataSetup->startSetup();
+
+        $connection = $this->moduleDataSetup->getConnection();
+        $storeTable = $this->moduleDataSetup->getTable('emico_attributelanding_page_store');
+        $pageTable = $this->moduleDataSetup->getTable('emico_attributelanding_page');
+
+        $connection->query(
+            sprintf(
+                'UPDATE %s s JOIN %s p ON s.page_id = p.page_id SET s.name = p.name WHERE s.name IS NULL',
+                $storeTable,
+                $pageTable
+            )
+        );
+
+        $this->moduleDataSetup->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public static function getDependencies(): array
+    {
+        return [ConvertLandingpageEntries::class];
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/src/Setup/Patch/Data/FixLandingPageStoreName.php
+++ b/src/Setup/Patch/Data/FixLandingPageStoreName.php
@@ -31,12 +31,12 @@ class FixLandingPageStoreName implements DataPatchInterface
         $storeTable = $this->moduleDataSetup->getTable('emico_attributelanding_page_store');
         $pageTable = $this->moduleDataSetup->getTable('emico_attributelanding_page');
 
+        $select = $connection->select()
+            ->join(['p' => $pageTable], 's.page_id = p.page_id', ['name' => 'p.name'])
+            ->where('s.name IS NULL');
+
         $connection->query(
-            sprintf(
-                'UPDATE %s s JOIN %s p ON s.page_id = p.page_id SET s.name = p.name WHERE s.name IS NULL',
-                $storeTable,
-                $pageTable
-            )
+            $connection->updateFromSelect($select, ['s' => $storeTable])
         );
 
         $this->moduleDataSetup->endSetup();


### PR DESCRIPTION
## Summary

- **Bug:** `ConvertLandingpageEntries` did not include `LandingPageInterface::NAME` in the list of fields copied from `emico_attributelanding_page` to `emico_attributelanding_page_store`, leaving the `name` column `NULL` for all migrated rows.
- **Crash:** `LandingPage::getName()` has a `string` return type with no null guard, so a `NULL` value from the database causes a fatal `TypeError` — breaking the overview page for any store that ran the migration patch.
- **Fix (fresh installs):** Added `LandingPageInterface::NAME` as the first entry in the `$fields` array in `ConvertLandingpageEntries` so new installs copy the name correctly.
- **Fix (existing installs):** Added a new data patch `FixLandingPageStoreName` that back-fills the `name` column via a single `UPDATE … JOIN` for rows where it is `NULL`. It declares `ConvertLandingpageEntries` as a dependency and is applied by running `bin/magento setup:upgrade`.
- **Defensive fix:** `LandingPage::getName()` now returns `?? ''` so a stray `NULL` (e.g. before the patch runs) returns an empty string instead of crashing.

Fixes #144.

## How to test

**Scenario 1 — Existing install (patch already ran, name is NULL)**

1. Confirm rows in `emico_attributelanding_page_store` have `name = NULL`.
2. Run `bin/magento setup:upgrade`.
3. Confirm `FixLandingPageStoreName` appears in `patch_list`.
4. Query `emico_attributelanding_page_store` — `name` should now match the value in `emico_attributelanding_page`.
5. Open the overview page; no `TypeError` should occur and landing page names render correctly.

---

**Scenario 2 — Fresh install (patch has never run)**

1. Install the module from scratch (or delete the `ConvertLandingpageEntries` entry from `patch_list` and re-run `setup:upgrade` on a clean dataset).
2. After `setup:upgrade`, query `emico_attributelanding_page_store` — `name` should be populated for every migrated row.
3. Open the overview page; landing page names render correctly.

---

**Scenario 3 — getName() null guard**

1. Manually set `name = NULL` for a row in `emico_attributelanding_page_store` (simulating a corrupt or pre-patch state).
2. Load the corresponding landing page on the frontend.
3. Confirm no `TypeError` is thrown; the name renders as an empty string.

---